### PR TITLE
MCI capture - handle save failures and use unique temp files

### DIFF
--- a/CaptureHelpers/MciCaptureHelper.cs
+++ b/CaptureHelpers/MciCaptureHelper.cs
@@ -86,14 +86,19 @@ partial class MciCaptureHelper : ICaptureHelper {
 
                 for(var i = 0; i < GENERATION_COUNT; i++) {
                     if(GenerationRecording[i]) {
-                        var willStop = StopRequested || DateTime.Now - StartTime > (1 + i) * GENERATION_STEP;
+                        var fastStop = StopRequested || Exception != null;
+                        var willStop = fastStop || DateTime.Now - StartTime > (1 + i) * GENERATION_STEP;
 
                         if(willStop) {
                             var alias = GetAlias(i);
 
-                            if(!StopRequested) {
-                                MciSend("save", alias, TEMP_FILE_PATH);
-                                TempFileToSampleProvider();
+                            if(!fastStop) {
+                                try {
+                                    MciSend("save", alias, TEMP_FILE_PATH);
+                                    TempFileToSampleProvider();
+                                } catch(Exception x) {
+                                    Exception ??= x;
+                                }
                             }
 
                             MciSend("close", alias);

--- a/CaptureHelpers/MciCaptureHelper.cs
+++ b/CaptureHelpers/MciCaptureHelper.cs
@@ -13,7 +13,6 @@ partial class MciCaptureHelper : ICaptureHelper {
     static readonly Lock SYNC = new();
     static readonly int GENERATION_COUNT = 3;
     static readonly TimeSpan GENERATION_STEP = TimeSpan.FromSeconds(4);
-    static readonly string TEMP_FILE_PATH = Path.Combine(Path.GetTempPath(), "shazam-for-real-tmp.wav");
 
     readonly bool[] GenerationRecording = new bool[GENERATION_COUNT];
     readonly List<IDisposable> PendingDispose = [];
@@ -35,9 +34,6 @@ partial class MciCaptureHelper : ICaptureHelper {
 
         foreach(var disposable in PendingDispose)
             disposable.Dispose();
-
-        if(File.Exists(TEMP_FILE_PATH))
-            File.Delete(TEMP_FILE_PATH);
     }
 
     public bool Live => true;
@@ -91,11 +87,13 @@ partial class MciCaptureHelper : ICaptureHelper {
 
                         if(willStop) {
                             var alias = GetAlias(i);
+                            var tempFilePath = default(string);
 
                             if(!fastStop) {
+                                tempFilePath = Path.GetTempFileName();
                                 try {
-                                    MciSend("save", alias, TEMP_FILE_PATH);
-                                    TempFileToSampleProvider();
+                                    MciSend("save", alias, tempFilePath);
+                                    TempFileToSampleProvider(tempFilePath);
                                 } catch(Exception x) {
                                     Exception ??= x;
                                 }
@@ -103,6 +101,10 @@ partial class MciCaptureHelper : ICaptureHelper {
 
                             MciSend("close", alias);
                             GenerationRecording[i] = false;
+
+                            if(tempFilePath != default) {
+                                File.Delete(tempFilePath);
+                            }
                         }
                     }
 
@@ -119,9 +121,9 @@ partial class MciCaptureHelper : ICaptureHelper {
         }
     }
 
-    void TempFileToSampleProvider() {
-        // Buffer into memory because temp file will be overwritten
-        var stream = WithPendingDispose(new MemoryStream(File.ReadAllBytes(TEMP_FILE_PATH)));
+    void TempFileToSampleProvider(string filePath) {
+        // Buffer into memory because temp file will be deleted
+        var stream = WithPendingDispose(new MemoryStream(File.ReadAllBytes(filePath)));
         var reader = WithPendingDispose(new WaveFileReader(stream));
         SampleProvider = reader.ToSampleProvider();
     }


### PR DESCRIPTION
### What changed

* Handle exceptions while saving a captured generation to a temporary WAV file.
* Use a unique temporary file for each save instead of a fixed shared filename.

### Why

The previous implementation used a single fixed temp file:

`%TEMP%\shazam-for-real-tmp.wav`

This can race when multiple application instances are capturing at the same time. One instance can overwrite the file while another is reading it:

```
error: Cannot save the specified file.  Make sure you have enough disk space or are still connected to the network.
```

The new implementation uses `Path.GetTempFileName()`, which provides a unique temporary filename and reserves it by creating the file. This is preferable here to generating a random name ourselves, since the reservation also avoids a race between choosing a filename and MCI creating/using it.

The saved WAV is immediately read into memory, so the temporary file can then be deleted without affecting the resulting `SampleProvider`.

### Exception handling

Saving is an operation that can fail for other reasons (for example, due to file access problems or insufficient disk space). Such a failure should be reported through `captureHelper.Exception` rather than terminating the worker thread unexpectedly.

After a save failure, `Exception != null` causes the remaining generations to fast-stop and be closed.

Exception handling is intentionally kept scoped to the save/read operation. There is no broad try/catch around all cleanup operations: unexpected failures in `close` or temp-file deletion are still allowed to propagate to the worker's existing top-level exception handler.

---

*Assisted by OpenAI 🤖*