### PR TITLE
Add unit tests for CaptureBuffer

### DIFF
--- a/CaptureHelpers/CaptureBuffer.cs
+++ b/CaptureHelpers/CaptureBuffer.cs
@@ -29,7 +29,7 @@ class CaptureBuffer {
 
     public CaptureBuffer()
         : this(CaptureHelper.WAVE_FORMAT, TimeSpan.FromSeconds(12)) {
-        // 12 sec is max 'retryMs' returned by Shazam API
+        // 12 sec is max 'retryInMilliseconds' returned by Shazam API
     }
 
     public CaptureBuffer(WaveFormat waveFormat, TimeSpan maxDuration) {

--- a/CaptureHelpers/CaptureBuffer.cs
+++ b/CaptureHelpers/CaptureBuffer.cs
@@ -9,9 +9,6 @@ using System.Threading.Tasks;
 namespace Project;
 
 class CaptureBuffer {
-    // Max RetryMs
-    static readonly TimeSpan MaxDuration = TimeSpan.FromSeconds(12);
-
     public readonly ISampleProvider SampleProvider;
 
     readonly BufferedWaveProvider WaveBuffer;
@@ -30,8 +27,16 @@ class CaptureBuffer {
         }
     }
 
-    public CaptureBuffer() {
-        WaveBuffer = new(CaptureHelper.WAVE_FORMAT, MaxDuration) {
+    public CaptureBuffer()
+        : this(CaptureHelper.WAVE_FORMAT, TimeSpan.FromSeconds(12)) {
+        // 12 sec is max 'retryMs' returned by Shazam API
+    }
+
+    public CaptureBuffer(WaveFormat waveFormat, TimeSpan maxDuration) {
+        Debug.Assert(waveFormat.Encoding == WaveFormatEncoding.Pcm);
+        Debug.Assert(waveFormat.BitsPerSample == 16);
+        Debug.Assert(waveFormat.Channels == 1);
+        WaveBuffer = new(waveFormat, maxDuration) {
             ReadFully = false
         };
         RemainingCount = WaveBuffer.BufferLength;
@@ -39,7 +44,7 @@ class CaptureBuffer {
     }
 
     public async Task ConsumeStreamAsync(Stream stream) {
-        using var memOwner = MemoryPool<byte>.Shared.Rent(Analysis.SAMPLE_RATE / 2);
+        using var memOwner = MemoryPool<byte>.Shared.Rent(WaveBuffer.WaveFormat.SampleRate / 2);
         var mem = memOwner.Memory;
         try {
             while(RemainingCount > 0) {

--- a/Test/CaptureBufferTests.cs
+++ b/Test/CaptureBufferTests.cs
@@ -11,23 +11,18 @@ namespace Project.Test;
 public class CaptureBufferTests {
     const int TestSampleRate = 123;
     const short PositiveHalfShort = short.MaxValue / 2;
+    const float ReadSentinel = 0xdeadbeef;
 
-    readonly float[] ReadBuf = new float[10 * TestSampleRate];
-
-    [Fact]
+[Fact]
     public void ZeroPadAfterMaxDuration() {
         var captureBuf = CreateCaptureBuffer(1);
-        var sp = captureBuf.SampleProvider;
 
         var firstBatchLen = TestSampleRate - 1;
         Add16BitSamples(captureBuf, PositiveHalfShort, firstBatchLen);
-        Assert.Equal(firstBatchLen, sp.Read(ReadBuf));
+        MustReadExactly(captureBuf, firstBatchLen, 0.5f);
 
         Add16BitSamples(captureBuf, PositiveHalfShort, TestSampleRate - firstBatchLen + 1);
-        Assert.Equal(ReadBuf.Length, sp.Read(ReadBuf));
-
-        Assert.Equal(0.5, ReadBuf[0], precision: 3);
-        Assert.Equal(0, ReadBuf[1], precision: 3);
+        MustReadZeroPadded(captureBuf, 1, 0.5f);
     }
 
     [Fact]
@@ -38,9 +33,7 @@ public class CaptureBufferTests {
         captureBuf.Stop();
         Add16BitSamples(captureBuf, PositiveHalfShort, 1);
 
-        Assert.Equal(ReadBuf.Length, captureBuf.SampleProvider.Read(ReadBuf));
-        Assert.Equal(0.5, ReadBuf[0], precision: 3);
-        Assert.Equal(0, ReadBuf[1], precision: 3);
+        MustReadZeroPadded(captureBuf, 1, 0.5f);
     }
 
     [Fact]
@@ -54,9 +47,7 @@ public class CaptureBufferTests {
 
         Assert.True(sourceStream.Position < sourceStream.Length);
 
-        captureBuf.SampleProvider.Read(ReadBuf);
-        Assert.Equal(0.5, ReadBuf[2 * TestSampleRate - 1], precision: 3);
-        Assert.Equal(0, ReadBuf[2 * TestSampleRate], precision: 3);
+        MustReadZeroPadded(captureBuf, 2 * TestSampleRate, 0.5f);
     }
 
     [Fact]
@@ -71,7 +62,7 @@ public class CaptureBufferTests {
         });
 
         Assert.Null(exception);
-        Assert.Equal(ReadBuf.Length, captureBuf.SampleProvider.Read(ReadBuf));
+        MustReadZeroPadded(captureBuf, 0);
     }
 
     static CaptureBuffer CreateCaptureBuffer(int maxDurationSeconds) {
@@ -92,5 +83,30 @@ public class CaptureBufferTests {
         for(var i = 0; i < sampleCount; i++) {
             writer.Write(sampleValue);
         }
+    }
+
+    static void MustReadExactly(CaptureBuffer captureBuf, int expectedSampleCount, float expectedLastSample = default) {
+        MustReadCore(false, captureBuf, expectedSampleCount, expectedLastSample);
+    }
+
+    static void MustReadZeroPadded(CaptureBuffer captureBuf, int expectedSampleCount, float expectedLastSample = default) {
+        MustReadCore(true, captureBuf, expectedSampleCount, expectedLastSample);
+    }
+
+    static void MustReadCore(bool zeroPadded, CaptureBuffer captureBuf, int expectedSampleCount, float expectedLastSample) {
+        var readBuf = new float[expectedSampleCount + 1];
+        Array.Fill(readBuf, ReadSentinel);
+        Assert.Equal(
+            zeroPadded ? readBuf.Length : expectedSampleCount,
+            captureBuf.SampleProvider.Read(readBuf)
+        );
+        if(expectedSampleCount > 0) {
+            Assert.Equal(expectedLastSample, readBuf[expectedSampleCount - 1], precision: 3);
+        }
+        Assert.Equal(
+            zeroPadded ? 0 : ReadSentinel,
+            readBuf[expectedSampleCount]
+        );
+
     }
 }

--- a/Test/CaptureBufferTests.cs
+++ b/Test/CaptureBufferTests.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Project.Test;
+
+public class CaptureBufferTests {
+    const int TestSampleRate = 123;
+    const short PositiveHalfShort = short.MaxValue / 2;
+
+    readonly float[] ReadBuf = new float[10 * TestSampleRate];
+
+    [Fact]
+    public void ZeroPadAfterMaxDuration() {
+        var captureBuf = CreateCaptureBuffer(1);
+        var sp = captureBuf.SampleProvider;
+
+        var firstBatchLen = TestSampleRate - 1;
+        Add16BitSamples(captureBuf, PositiveHalfShort, firstBatchLen);
+        Assert.Equal(firstBatchLen, sp.Read(ReadBuf));
+
+        Add16BitSamples(captureBuf, PositiveHalfShort, TestSampleRate - firstBatchLen + 1);
+        Assert.Equal(ReadBuf.Length, sp.Read(ReadBuf));
+
+        Assert.Equal(0.5, ReadBuf[0], precision: 3);
+        Assert.Equal(0, ReadBuf[1], precision: 3);
+    }
+
+    [Fact]
+    public void Stop() {
+        var captureBuf = CreateCaptureBuffer(123);
+
+        Add16BitSamples(captureBuf, PositiveHalfShort, 1);
+        captureBuf.Stop();
+        Add16BitSamples(captureBuf, PositiveHalfShort, 1);
+
+        Assert.Equal(ReadBuf.Length, captureBuf.SampleProvider.Read(ReadBuf));
+        Assert.Equal(0.5, ReadBuf[0], precision: 3);
+        Assert.Equal(0, ReadBuf[1], precision: 3);
+    }
+
+    [Fact]
+    public async Task ConsumeStreamAsync() {
+        using var sourceStream = new MemoryStream();
+        Add16BitSamples(sourceStream, PositiveHalfShort, 3 * TestSampleRate);
+        sourceStream.Position = 0;
+
+        var captureBuf = CreateCaptureBuffer(2);
+        await captureBuf.ConsumeStreamAsync(sourceStream);
+
+        Assert.True(sourceStream.Position < sourceStream.Length);
+
+        captureBuf.SampleProvider.Read(ReadBuf);
+        Assert.Equal(0.5, ReadBuf[2 * TestSampleRate - 1], precision: 3);
+        Assert.Equal(0, ReadBuf[2 * TestSampleRate], precision: 3);
+    }
+
+    [Fact]
+    public async Task ConsumeStreamAsync_Disposed() {
+        var sourceStream = new MemoryStream();
+        sourceStream.Dispose();
+
+        var captureBuf = CreateCaptureBuffer(123);
+
+        var exception = await Record.ExceptionAsync(async delegate {
+            await captureBuf.ConsumeStreamAsync(sourceStream);
+        });
+
+        Assert.Null(exception);
+        Assert.Equal(ReadBuf.Length, captureBuf.SampleProvider.Read(ReadBuf));
+    }
+
+    static CaptureBuffer CreateCaptureBuffer(int maxDurationSeconds) {
+        return new CaptureBuffer(
+            new(TestSampleRate, 1),
+            TimeSpan.FromSeconds(maxDurationSeconds)
+        );
+    }
+
+    static void Add16BitSamples(CaptureBuffer captureBuf, short sampleValue, int sampleCount) {
+        var samples = new short[sampleCount];
+        Array.Fill(samples, sampleValue);
+        captureBuf.AddRange(MemoryMarshal.Cast<short, byte>(samples));
+    }
+
+    static void Add16BitSamples(Stream stream, short sampleValue, int sampleCount) {
+        using var writer = new BinaryWriter(stream, Encoding.Default, true);
+        for(var i = 0; i < sampleCount; i++) {
+            writer.Write(sampleValue);
+        }
+    }
+}

--- a/Test/CaptureBufferTests.cs
+++ b/Test/CaptureBufferTests.cs
@@ -13,7 +13,7 @@ public class CaptureBufferTests {
     const short PositiveHalfShort = short.MaxValue / 2;
     const float ReadSentinel = 0xdeadbeef;
 
-[Fact]
+    [Fact]
     public void ZeroPadAfterMaxDuration() {
         var captureBuf = CreateCaptureBuffer(1);
 

--- a/Test/CaptureBufferTests.cs
+++ b/Test/CaptureBufferTests.cs
@@ -51,6 +51,20 @@ public class CaptureBufferTests {
     }
 
     [Fact]
+    public async Task ConsumeStreamAsync_Short() {
+        using var sourceStream = new MemoryStream();
+        Add16BitSamples(sourceStream, PositiveHalfShort, TestSampleRate);
+        sourceStream.Position = 0;
+
+        var captureBuf = CreateCaptureBuffer(2);
+        await captureBuf.ConsumeStreamAsync(sourceStream);
+
+        Assert.Equal(sourceStream.Length, sourceStream.Position);
+
+        MustReadZeroPadded(captureBuf, TestSampleRate, 0.5f);
+    }
+
+    [Fact]
     public async Task ConsumeStreamAsync_Disposed() {
         var sourceStream = new MemoryStream();
         sourceStream.Dispose();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable audio capture formats and maximum durations.
  * Audio processing now adapts to the selected format’s sample rate.
  * The default configuration remains 16-bit mono audio with a 12-second duration.

* **Bug Fixes**
  * Improved handling of short streams, including complete consumption and zero-padding.
  * Preserved reliable stopping, disposal, truncation, and maximum-duration behavior.

* **Tests**
  * Expanded coverage for asynchronous stream consumption and capture-buffer edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->