### PR TITLE
CaptureBuffer - trim leading silence

### DIFF
--- a/CaptureHelpers/CaptureBuffer.cs
+++ b/CaptureHelpers/CaptureBuffer.cs
@@ -45,9 +45,15 @@ class CaptureBuffer {
         WaveBuffer = new(waveFormat, maxDuration) {
             ReadFully = false
         };
-        RemainingTrim = (int)maxTrim.TotalSeconds * waveFormat.AverageBytesPerSecond;
+        RemainingTrim = TimeToBlockAlignedBytes(waveFormat, maxTrim);
         RemainingCount = WaveBuffer.BufferLength;
         SampleProvider = WaveBuffer.ToSampleProvider();
+    }
+
+    static int TimeToBlockAlignedBytes(WaveFormat waveFormat, TimeSpan time) {
+        var byteCount = (int)(time.TotalSeconds * waveFormat.AverageBytesPerSecond);
+        return byteCount - (byteCount % waveFormat.BlockAlign);
+
     }
 
     public async Task ConsumeStreamAsync(Stream stream) {

--- a/CaptureHelpers/CaptureBuffer.cs
+++ b/CaptureHelpers/CaptureBuffer.cs
@@ -53,7 +53,6 @@ class CaptureBuffer {
     static int TimeToBlockAlignedBytes(WaveFormat waveFormat, TimeSpan time) {
         var byteCount = (int)(time.TotalSeconds * waveFormat.AverageBytesPerSecond);
         return byteCount - (byteCount % waveFormat.BlockAlign);
-
     }
 
     public async Task ConsumeStreamAsync(Stream stream) {

--- a/CaptureHelpers/CaptureBuffer.cs
+++ b/CaptureHelpers/CaptureBuffer.cs
@@ -4,6 +4,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 namespace Project;
@@ -14,6 +15,8 @@ class CaptureBuffer {
     readonly BufferedWaveProvider WaveBuffer;
 
     int PendingByte = -1;
+
+    int RemainingTrim;
 
     int RemainingCount {
         get;
@@ -30,11 +33,11 @@ class CaptureBuffer {
     }
 
     public CaptureBuffer()
-        : this(CaptureHelper.WAVE_FORMAT, TimeSpan.FromSeconds(12)) {
+        : this(CaptureHelper.WAVE_FORMAT, TimeSpan.FromSeconds(12), TimeSpan.FromSeconds(1)) {
         // 12 sec is max 'retryInMilliseconds' returned by Shazam API
     }
 
-    public CaptureBuffer(WaveFormat waveFormat, TimeSpan maxDuration) {
+    public CaptureBuffer(WaveFormat waveFormat, TimeSpan maxDuration, TimeSpan maxTrim) {
         Debug.Assert(waveFormat.Encoding == WaveFormatEncoding.Pcm);
         Debug.Assert(waveFormat.BitsPerSample == 16);
         Debug.Assert(waveFormat.Channels == 1);
@@ -42,6 +45,7 @@ class CaptureBuffer {
         WaveBuffer = new(waveFormat, maxDuration) {
             ReadFully = false
         };
+        RemainingTrim = (int)maxTrim.TotalSeconds * waveFormat.AverageBytesPerSecond;
         RemainingCount = WaveBuffer.BufferLength;
         SampleProvider = WaveBuffer.ToSampleProvider();
     }
@@ -91,6 +95,7 @@ class CaptureBuffer {
     }
 
     void AddAligned(ReadOnlySpan<byte> bytes) {
+        bytes = Trim(bytes);
         if(RemainingCount < bytes.Length) {
             bytes = bytes[..RemainingCount];
         }
@@ -98,6 +103,22 @@ class CaptureBuffer {
             WaveBuffer.AddSamples(bytes);
             RemainingCount -= bytes.Length;
         }
+    }
+
+    ReadOnlySpan<byte> Trim(ReadOnlySpan<byte> bytes) {
+        // Rationale: mic recording starts with ~350ms of silence
+        // which is better to exclude from signature
+        if(RemainingTrim < 1) {
+            return bytes;
+        }
+        var nonSilentPcmIndex = MemoryMarshal.Cast<byte, short>(bytes).IndexOfAnyExceptInRange((short)-1, (short)1);
+        var trimCount = Math.Min(RemainingTrim, nonSilentPcmIndex < 0 ? bytes.Length : 2 * nonSilentPcmIndex);
+        if(nonSilentPcmIndex < 0) {
+            RemainingTrim -= trimCount;
+        } else {
+            RemainingTrim = 0;
+        }
+        return bytes[trimCount..];
     }
 
     public void Stop() {

--- a/Test/CaptureBufferTests.cs
+++ b/Test/CaptureBufferTests.cs
@@ -108,10 +108,35 @@ public class CaptureBufferTests {
         MustReadExactly(captureBuf, 1, 0.5f);
     }
 
-    static CaptureBuffer CreateCaptureBuffer(int maxDurationSeconds) {
+    [Fact]
+    public void Trim_Disabled() {
+        var captureBuf = CreateCaptureBuffer(2, 0);
+        Add16BitSamples(captureBuf, 0, TestSampleRate / 2);
+        MustReadExactly(captureBuf, TestSampleRate / 2);
+    }
+
+    [Fact]
+    public void Trim_Full() {
+        var captureBuf = CreateCaptureBuffer(2, 1);
+        Add16BitSamples(captureBuf, 0, TestSampleRate + 1);
+        Add16BitSamples(captureBuf, PositiveHalfShort, 1);
+        MustReadExactly(captureBuf, 2, 0.5f);
+    }
+
+    [Fact]
+    public void Trim_Partial() {
+        var captureBuf = CreateCaptureBuffer(2, 1);
+        Add16BitSamples(captureBuf, 0, TestSampleRate / 2);
+        Add16BitSamples(captureBuf, PositiveHalfShort, 1); // cancels subsequent trimming
+        Add16BitSamples(captureBuf, 0, 1);
+        MustReadExactly(captureBuf, 2, 0);
+    }
+
+    static CaptureBuffer CreateCaptureBuffer(int maxDurationSeconds, int maxTrimSeconds = 0) {
         return new CaptureBuffer(
             new(TestSampleRate, 1),
-            TimeSpan.FromSeconds(maxDurationSeconds)
+            TimeSpan.FromSeconds(maxDurationSeconds),
+            TimeSpan.FromSeconds(maxTrimSeconds)
         );
     }
 

--- a/Test/CaptureBufferTests.cs
+++ b/Test/CaptureBufferTests.cs
@@ -126,10 +126,13 @@ public class CaptureBufferTests {
     [Fact]
     public void Trim_Partial() {
         var captureBuf = CreateCaptureBuffer(2, 1);
+
         Add16BitSamples(captureBuf, 0, TestSampleRate / 2);
         Add16BitSamples(captureBuf, PositiveHalfShort, 1); // cancels subsequent trimming
+        MustReadExactly(captureBuf, 1, 0.5f);
+
         Add16BitSamples(captureBuf, 0, 1);
-        MustReadExactly(captureBuf, 2, 0);
+        MustReadExactly(captureBuf, 1, 0);
     }
 
     static CaptureBuffer CreateCaptureBuffer(int maxDurationSeconds, int maxTrimSeconds = 0) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable trimming of leading silence from 16-bit PCM audio.
  * Trimming can be disabled or limited to a selected duration.
  * The default configuration trims up to one second of initial silence.
  * Leading near-silent audio is removed before recording data is buffered, helping recordings begin with less unwanted silence.

* **Tests**
  * Added coverage for disabled, complete, and partial silence-trimming scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->