### PR TITLE
CaptureBuffer - simplify AddRange

### DIFF
--- a/CaptureHelpers/CaptureBuffer.cs
+++ b/CaptureHelpers/CaptureBuffer.cs
@@ -67,26 +67,22 @@ class CaptureBuffer {
     }
 
     public void AddRange(ReadOnlySpan<byte> bytes) {
-        if(bytes.Length < 1 || RemainingCount < 1) {
+        if(bytes.IsEmpty || RemainingCount < 1) {
             return;
         }
-        var even = int.IsEvenInteger(bytes.Length);
-        if(PendingByte < 0) {
-            if(even) {
-                AddAligned(bytes);
-            } else {
-                AddAligned(bytes[..^1]);
-                PendingByte = bytes[^1];
-            }
-        } else {
+        if(PendingByte > -1) {
             AddAligned([(byte)PendingByte, bytes[0]]);
-            if(even) {
-                AddAligned(bytes[1..^1]);
-                PendingByte = bytes[^1];
-            } else {
-                AddAligned(bytes[1..]);
-                PendingByte = -1;
+            bytes = bytes[1..];
+            PendingByte = -1;
+            if(bytes.IsEmpty) {
+                return;
             }
+        }
+        if(int.IsEvenInteger(bytes.Length)) {
+            AddAligned(bytes);
+        } else {
+            AddAligned(bytes[..^1]);
+            PendingByte = bytes[^1];
         }
     }
 


### PR DESCRIPTION
## From ChatGPT

I'd make the length invariants explicit so the reader doesn't have to mentally prove each range.

### Why I prefer this

The original has two separate notions intertwined:

1. Do we have a pending byte?
2. Is the current span's length even?

By consuming the pending byte up front, the remainder has a much simpler invariant:

> **After the first block, `bytes` is non-empty and `PendingByte < 0`.**

Then there's only one decision:

```text
remaining length
      │
 ┌────┴────┐
even      odd
 │          │
all       all but last
             │
          save last
```

And the only ranges left are:

```csharp
bytes = bytes[1..];  // known non-empty before this
bytes[..^1];         // safe because odd length >= 1
bytes[^1];           // safe because non-empty
```

There's also a nice property here: `bytes[1..]` can become empty, but we immediately handle that with `IsEmpty`, so the invariant is easy to maintain.

### One subtle behavioral difference

The rewrite does:

```csharp
PendingByte = -1;
```

immediately after consuming it. That's equivalent to your original code in the cases where the method proceeds normally, but if `AddAligned` can somehow throw, the observable state differs. If `AddAligned` is guaranteed not to throw, irrelevant; otherwise I'd preserve your original state-transition ordering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved byte buffering and alignment behavior when processing incoming data.
  * Added safer handling for empty input, exhausted buffers, and pending bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->